### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -2,15 +2,14 @@
     Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
     Any future edits should abide by this format.
 -->
-
 # Prometheus ECS Discovery
 
 A service which runs on AWS ECS and collates a list of containers also running on AWS ECS so Prometheus can scrape them.
 This allows us to automatically collect runtime metrics from our applications running on ECS and exposing Prometheus metrics on a `/metrics` endpoint.
 
-## More Information
+## Code
 
-Forked from [teralytics/prometheus-ecs-discovery](https://github.com/teralytics/prometheus-ecs-discovery).
+prometheus-ecs-discovery
 
 ## Primary URL
 
@@ -20,26 +19,21 @@ N/A
 
 Platinum
 
-## Lifecycle Stage
-
-Production
-
 ## Host Platform
 
 AWS ECS
 
-## Delivered By
+## Contains Personal Data
 
-[reliability-engineering](https://biz-ops.in.ft.com/Team/reliability-engineering)
+No
 
-## Supported By
+## Contains Sensitive Data
 
-[reliability-engineering](https://biz-ops.in.ft.com/Team/reliability-engineering)
+No
 
-## Known About By
+## Lifecycle Stage
 
-- nikita.lohia
-- eric.anand
+Production
 
 ## First Line Troubleshooting
 
@@ -53,7 +47,7 @@ View the generic troubleshooting information for the AWS ECS cluster (including 
 
 The service discovery component runs two containers per task: each collects service discovery information for a particular region. These are written to separate files.
 
-## Bespoke Monitoring
+## Monitoring
 
 The Heimdall Prometheus has some bespoke alarms which are sent to the [#rel-eng-alerts](https://financialtimes.slack.com/messages/C8QL0GY9J) Slack via alertmanager.
 
@@ -61,8 +55,8 @@ These are visible in the [Alertmanager UI](https://alertmanager.in.ft.com/) if t
 
 There are several Grafana dashboards:
 
--   [AWS ECS Task metrics](http://grafana.ft.com/d/YCsaeAFiz/aws-ecs-operations-and-reliability?orgId=1&var-region=eu-west-1&var-cluster=mon-agg-ecs&var-service=mon-agg-ecs-service-prometheus-ecs-discovery-Service-1OY1CGBRU4NXW) (`us-east-1` metrics are available using the dropdowns).
--   [Go language runtime metrics](http://grafana.ft.com/d/c0mUzOcmz/go-processes?orgId=1&var-system=prometheus-ecs-discovery-exporter&var-cluster_name=All&var-container=prometheus-ecs-discovery-exporter-service&var-task_revision=All&var-instance=All&var-interval=10m) - note: this dashboard is based on metrics from containers discovered using this service, and may indicate what targets are available.
+*   [AWS ECS Task metrics](http://grafana.ft.com/d/YCsaeAFiz/aws-ecs-operations-and-reliability?orgId=1&var-region=eu-west-1&var-cluster=mon-agg-ecs&var-service=mon-agg-ecs-service-prometheus-ecs-discovery-Service-1OY1CGBRU4NXW) (`us-east-1` metrics are available using the dropdowns).
+*   [Go language runtime metrics](http://grafana.ft.com/d/c0mUzOcmz/go-processes?orgId=1&var-system=prometheus-ecs-discovery-exporter&var-cluster_name=All&var-container=prometheus-ecs-discovery-exporter-service&var-task_revision=All&var-instance=All&var-interval=10m) - note: this dashboard is based on metrics from containers discovered using this service, and may indicate what targets are available.
 
 Logs are available in [Splunk](https://financialtimes.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22operations-reliability%22%20attrs.com.ft.service-name%3D%22prometheus-ecs-discovery*%22%20attrs.com.ft.service-region%3D%22*%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-1h&latest=now) via the query:
 
@@ -71,22 +65,6 @@ index="operations-reliability" attrs.com.ft.service-name="prometheus-ecs-discove
 ```
 
 the `source` parameter can be specified more exactly to include only relevant component if needed.
-
-## Contains Personal Data
-
-False
-
-## Contains Sensitive Data
-
-False
-
-## Architecture
-
-Diagram for the exporter:
-
-![prometheus-ecs-discovery-architecture](./architecture/prometheus-ecs-discovery-architecture.png)
-
-[View in Lucidchart](https://www.lucidchart.com/invitations/accept/3ef3819f-ff35-4f3f-a393-eecd21ea0d15).
 
 ## Failover Architecture Type
 
@@ -99,6 +77,10 @@ FullyAutomated
 ## Failback Process Type
 
 FullyAutomated
+
+## Failover Details
+
+Writes configuration to a AWS EFS files in a single region. Cross-region is not applicable.
 
 ## Data Recovery Process Type
 
@@ -120,15 +102,15 @@ Manual
 
 Release:
 
--   Merge a commit to master
--   [CircleCI](https://circleci.com/gh/Financial-Times/workflows/prometheus-ecs-discovery) will build and deploy the commit.
+*   Merge a commit to master
+*   [CircleCI](https://circleci.com/gh/Financial-Times/workflows/prometheus-ecs-discovery) will build and deploy the commit.
 
 Rollback:
 
--   Open CircleCI for this project: [circleci:prometheus-ecs-discovery](https://circleci.com/gh/Financial-Times/workflows/prometheus-ecs-discovery)
--   Find the build of the commit which you wish to roll back to. The commit message is visible, and the `sha` of the commit is displayed to the right
--   Click on `Rerun`, under the build status for each workflow
--   Click `Rerun from beginning`
+*   Open CircleCI for this project: [circleci:prometheus-ecs-discovery](https://circleci.com/gh/Financial-Times/workflows/prometheus-ecs-discovery)
+*   Find the build of the commit which you wish to roll back to. The commit message is visible, and the `sha` of the commit is displayed to the right
+*   Click on `Rerun`, under the build status for each workflow
+*   Click `Rerun from beginning`
 
 ## Key Management Process Type
 
@@ -140,7 +122,15 @@ The systems secrets are set at build time as parameters in the services Cloudfor
 
 They come from two sources:
 
-1. The CircleCI environment variables for the CircleCI project.
-2. The CircleCI context used in the [CircleCI config](https://github.com/Financial-Times/prometheus-ecs-discovery/blob/master/.circleci/config.yml).
+1.  The CircleCI environment variables for the CircleCI project.
+2.  The CircleCI context used in the [CircleCI config](https://github.com/Financial-Times/prometheus-ecs-discovery/blob/master/.circleci/config.yml).
 
 See the [README](https://github.com/Financial-Times/prometheus-ecs-discovery#prometheus-amazon-ecs-discovery) for more details.
+
+## Architecture
+
+Diagram for the exporter:
+
+![prometheus-ecs-discovery-architecture](./architecture/prometheus-ecs-discovery-architecture.png)
+
+[View in Lucidchart](https://www.lucidchart.com/invitations/accept/3ef3819f-ff35-4f3f-a393-eecd21ea0d15).


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/prometheus-ecs-discovery/blob/runbook-no-relationships-2021-03-15/RUNBOOK.md) file has been automatically regenerated from the Biz Ops data for the **prometheus-ecs-discovery** system.
 - All the relationships have been excluded from RUNBOOK.md but are still in the **prometheus-ecs-discovery** system in [Biz Ops](https://biz-ops.in.ft.com/System/prometheus-ecs-discovery).
 - Please continue to manage the relationships manually or via the Biz Ops API.

## Why
 - The model of ownership/deliveredBy/SupportedBy [has been changed](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).
 - The previous management of relationships within RUNBOOK.md caused confusion.
 - Relationships were being locked from edit when they needed to be changed.

## Next Steps
 - Please merge this PR **AND** trigger a production release to unlock the relationships in Biz Ops.
 - Check the new **Delivered By**, **Supported By** and **Commissioned By** relationships to confirm they define the correct ownership/responsibilities.
