### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -27,6 +27,14 @@ Production
 
 AWS ECS
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Architecture
 
 Diagram for the exporter:
@@ -50,6 +58,14 @@ No
 ## Can Contact Individuals
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Risk
+Enter descriptive text satisfying the following:
+More details of what kind of data is held/processed in this system, and what the associated risks are.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -2,15 +2,14 @@
     Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
     Any future edits should abide by this format.
 -->
-
 # Prometheus ECS Discovery
 
 A service which runs on AWS ECS and collates a list of containers also running on AWS ECS so Prometheus can scrape them.
 This allows us to automatically collect runtime metrics from our applications running on ECS and exposing Prometheus metrics on a `/metrics` endpoint.
 
-## More Information
+## Code
 
-Forked from [teralytics/prometheus-ecs-discovery](https://github.com/teralytics/prometheus-ecs-discovery).
+prometheus-ecs-discovery
 
 ## Primary URL
 
@@ -28,58 +27,6 @@ Production
 
 AWS ECS
 
-## Delivered By
-
-[reliability-engineering](https://biz-ops.in.ft.com/Team/reliability-engineering)
-
-## Supported By
-
-[reliability-engineering](https://biz-ops.in.ft.com/Team/reliability-engineering)
-
-## Known About By
-
-- nikita.lohia
-- eric.anand
-
-## First Line Troubleshooting
-
-It may be useful to view the latest targets Prometheus has read from the written config file using the targets interface for the [EU](https://prometheus-eu-west-1.in.ft.com/targets#job-application) and [US](https://prometheus-us-east-1.in.ft.com/targets#job-application) prometheus instances. If this list does not contain any instances, or does not contain the expected instance, it is likely there is an issue with the running of the ECS discovery service, or accessing the ECS API in a given region.
-
-AWS credentials are obtained using an ECS task role and so should not require keys or require human intervention due to expiry.
-
-View the generic troubleshooting information for the AWS ECS cluster (including services running on the cluster) which the application runs on: [monitoring-aggregation-ecs](https://github.com/Financial-Times/monitoring-aggregation-ecs/blob/master/documentation/RUNBOOK.md).
-
-## Second Line Troubleshooting
-
-The service discovery component runs two containers per task: each collects service discovery information for a particular region. These are written to separate files.
-
-## Bespoke Monitoring
-
-The Heimdall Prometheus has some bespoke alarms which are sent to the [#rel-eng-alerts](https://financialtimes.slack.com/messages/C8QL0GY9J) Slack via alertmanager.
-
-These are visible in the [Alertmanager UI](https://alertmanager.in.ft.com/) if they are firing.
-
-There are several Grafana dashboards:
-
--   [AWS ECS Task metrics](http://grafana.ft.com/d/YCsaeAFiz/aws-ecs-operations-and-reliability?orgId=1&var-region=eu-west-1&var-cluster=mon-agg-ecs&var-service=mon-agg-ecs-service-prometheus-ecs-discovery-Service-1OY1CGBRU4NXW) (`us-east-1` metrics are available using the dropdowns).
--   [Go language runtime metrics](http://grafana.ft.com/d/c0mUzOcmz/go-processes?orgId=1&var-system=prometheus-ecs-discovery-exporter&var-cluster_name=All&var-container=prometheus-ecs-discovery-exporter-service&var-task_revision=All&var-instance=All&var-interval=10m) - note: this dashboard is based on metrics from containers discovered using this service, and may indicate what targets are available.
-
-Logs are available in [Splunk](https://financialtimes.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22operations-reliability%22%20attrs.com.ft.service-name%3D%22prometheus-ecs-discovery*%22%20attrs.com.ft.service-region%3D%22*%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-1h&latest=now) via the query:
-
-```splunk
-index="operations-reliability" attrs.com.ft.service-name="prometheus-ecs-discovery-*-service" attrs.com.ft.service-region="*"
-```
-
-the `source` parameter can be specified more exactly to include only relevant component if needed.
-
-## Contains Personal Data
-
-False
-
-## Contains Sensitive Data
-
-False
-
 ## Architecture
 
 Diagram for the exporter:
@@ -87,6 +34,14 @@ Diagram for the exporter:
 ![prometheus-ecs-discovery-architecture](./architecture/prometheus-ecs-discovery-architecture.png)
 
 [View in Lucidchart](https://www.lucidchart.com/invitations/accept/3ef3819f-ff35-4f3f-a393-eecd21ea0d15).
+
+## Contains Personal Data
+
+No
+
+## Contains Sensitive Data
+
+No
 
 ## Failover Architecture Type
 
@@ -99,6 +54,10 @@ FullyAutomated
 ## Failback Process Type
 
 FullyAutomated
+
+## Failover Details
+
+Writes configuration to a AWS EFS files in a single region. Cross-region is not applicable.
 
 ## Data Recovery Process Type
 
@@ -120,15 +79,15 @@ Manual
 
 Release:
 
--   Merge a commit to master
--   [CircleCI](https://circleci.com/gh/Financial-Times/workflows/prometheus-ecs-discovery) will build and deploy the commit.
+*   Merge a commit to master
+*   [CircleCI](https://circleci.com/gh/Financial-Times/workflows/prometheus-ecs-discovery) will build and deploy the commit.
 
 Rollback:
 
--   Open CircleCI for this project: [circleci:prometheus-ecs-discovery](https://circleci.com/gh/Financial-Times/workflows/prometheus-ecs-discovery)
--   Find the build of the commit which you wish to roll back to. The commit message is visible, and the `sha` of the commit is displayed to the right
--   Click on `Rerun`, under the build status for each workflow
--   Click `Rerun from beginning`
+*   Open CircleCI for this project: [circleci:prometheus-ecs-discovery](https://circleci.com/gh/Financial-Times/workflows/prometheus-ecs-discovery)
+*   Find the build of the commit which you wish to roll back to. The commit message is visible, and the `sha` of the commit is displayed to the right
+*   Click on `Rerun`, under the build status for each workflow
+*   Click `Rerun from beginning`
 
 ## Key Management Process Type
 
@@ -140,7 +99,38 @@ The systems secrets are set at build time as parameters in the services Cloudfor
 
 They come from two sources:
 
-1. The CircleCI environment variables for the CircleCI project.
-2. The CircleCI context used in the [CircleCI config](https://github.com/Financial-Times/prometheus-ecs-discovery/blob/master/.circleci/config.yml).
+1.  The CircleCI environment variables for the CircleCI project.
+2.  The CircleCI context used in the [CircleCI config](https://github.com/Financial-Times/prometheus-ecs-discovery/blob/master/.circleci/config.yml).
 
 See the [README](https://github.com/Financial-Times/prometheus-ecs-discovery#prometheus-amazon-ecs-discovery) for more details.
+
+## First Line Troubleshooting
+
+It may be useful to view the latest targets Prometheus has read from the written config file using the targets interface for the [EU](https://prometheus-eu-west-1.in.ft.com/targets#job-application) and [US](https://prometheus-us-east-1.in.ft.com/targets#job-application) prometheus instances. If this list does not contain any instances, or does not contain the expected instance, it is likely there is an issue with the running of the ECS discovery service, or accessing the ECS API in a given region.
+
+AWS credentials are obtained using an ECS task role and so should not require keys or require human intervention due to expiry.
+
+View the generic troubleshooting information for the AWS ECS cluster (including services running on the cluster) which the application runs on: [monitoring-aggregation-ecs](https://github.com/Financial-Times/monitoring-aggregation-ecs/blob/master/documentation/RUNBOOK.md).
+
+## Second Line Troubleshooting
+
+The service discovery component runs two containers per task: each collects service discovery information for a particular region. These are written to separate files.
+
+## Monitoring
+
+The Heimdall Prometheus has some bespoke alarms which are sent to the [#rel-eng-alerts](https://financialtimes.slack.com/messages/C8QL0GY9J) Slack via alertmanager.
+
+These are visible in the [Alertmanager UI](https://alertmanager.in.ft.com/) if they are firing.
+
+There are several Grafana dashboards:
+
+*   [AWS ECS Task metrics](http://grafana.ft.com/d/YCsaeAFiz/aws-ecs-operations-and-reliability?orgId=1&var-region=eu-west-1&var-cluster=mon-agg-ecs&var-service=mon-agg-ecs-service-prometheus-ecs-discovery-Service-1OY1CGBRU4NXW) (`us-east-1` metrics are available using the dropdowns).
+*   [Go language runtime metrics](http://grafana.ft.com/d/c0mUzOcmz/go-processes?orgId=1&var-system=prometheus-ecs-discovery-exporter&var-cluster_name=All&var-container=prometheus-ecs-discovery-exporter-service&var-task_revision=All&var-instance=All&var-interval=10m) - note: this dashboard is based on metrics from containers discovered using this service, and may indicate what targets are available.
+
+Logs are available in [Splunk](https://financialtimes.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22operations-reliability%22%20attrs.com.ft.service-name%3D%22prometheus-ecs-discovery*%22%20attrs.com.ft.service-region%3D%22*%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-1h&latest=now) via the query:
+
+```splunk
+index="operations-reliability" attrs.com.ft.service-name="prometheus-ecs-discovery-*-service" attrs.com.ft.service-region="*"
+```
+
+the `source` parameter can be specified more exactly to include only relevant component if needed.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -11,6 +11,10 @@ This allows us to automatically collect runtime metrics from our applications ru
 
 prometheus-ecs-discovery
 
+## More Information
+
+Forked from [teralytics/prometheus-ecs-discovery](https://github.com/teralytics/prometheus-ecs-discovery).
+
 ## Primary URL
 
 N/A
@@ -27,21 +31,36 @@ Production
 
 AWS ECS
 
-<!-- Placeholder - remove HTML comment markers to activate
-## Heroku Pipeline Name
-Enter descriptive text satisfying the following:
-This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+## First Line Troubleshooting
 
-...or delete this placeholder if not applicable to this system
--->
+It may be useful to view the latest targets Prometheus has read from the written config file using the targets interface for the [EU](https://prometheus-eu-west-1.in.ft.com/targets#job-application) and [US](https://prometheus-us-east-1.in.ft.com/targets#job-application) prometheus instances. If this list does not contain any instances, or does not contain the expected instance, it is likely there is an issue with the running of the ECS discovery service, or accessing the ECS API in a given region.
 
-## Architecture
+AWS credentials are obtained using an ECS task role and so should not require keys or require human intervention due to expiry.
 
-Diagram for the exporter:
+View the generic troubleshooting information for the AWS ECS cluster (including services running on the cluster) which the application runs on: [monitoring-aggregation-ecs](https://github.com/Financial-Times/monitoring-aggregation-ecs/blob/master/documentation/RUNBOOK.md).
 
-![prometheus-ecs-discovery-architecture](./architecture/prometheus-ecs-discovery-architecture.png)
+## Second Line Troubleshooting
 
-[View in Lucidchart](https://www.lucidchart.com/invitations/accept/3ef3819f-ff35-4f3f-a393-eecd21ea0d15).
+The service discovery component runs two containers per task: each collects service discovery information for a particular region. These are written to separate files.
+
+## Monitoring
+
+The Heimdall Prometheus has some bespoke alarms which are sent to the [#rel-eng-alerts](https://financialtimes.slack.com/messages/C8QL0GY9J) Slack via alertmanager.
+
+These are visible in the [Alertmanager UI](https://alertmanager.in.ft.com/) if they are firing.
+
+There are several Grafana dashboards:
+
+*   [AWS ECS Task metrics](http://grafana.ft.com/d/YCsaeAFiz/aws-ecs-operations-and-reliability?orgId=1&var-region=eu-west-1&var-cluster=mon-agg-ecs&var-service=mon-agg-ecs-service-prometheus-ecs-discovery-Service-1OY1CGBRU4NXW) (`us-east-1` metrics are available using the dropdowns).
+*   [Go language runtime metrics](http://grafana.ft.com/d/c0mUzOcmz/go-processes?orgId=1&var-system=prometheus-ecs-discovery-exporter&var-cluster_name=All&var-container=prometheus-ecs-discovery-exporter-service&var-task_revision=All&var-instance=All&var-interval=10m) - note: this dashboard is based on metrics from containers discovered using this service, and may indicate what targets are available.
+
+Logs are available in [Splunk](https://financialtimes.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22operations-reliability%22%20attrs.com.ft.service-name%3D%22prometheus-ecs-discovery*%22%20attrs.com.ft.service-region%3D%22*%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-1h&latest=now) via the query:
+
+```splunk
+index="operations-reliability" attrs.com.ft.service-name="prometheus-ecs-discovery-*-service" attrs.com.ft.service-region="*"
+```
+
+the `source` parameter can be specified more exactly to include only relevant component if needed.
 
 ## Contains Personal Data
 
@@ -59,13 +78,13 @@ No
 
 No
 
-<!-- Placeholder - remove HTML comment markers to activate
-## Risk
-Enter descriptive text satisfying the following:
-More details of what kind of data is held/processed in this system, and what the associated risks are.
+## Architecture
 
-...or delete this placeholder if not applicable to this system
--->
+Diagram for the exporter:
+
+![prometheus-ecs-discovery-architecture](./architecture/prometheus-ecs-discovery-architecture.png)
+
+[View in Lucidchart](https://www.lucidchart.com/invitations/accept/3ef3819f-ff35-4f3f-a393-eecd21ea0d15).
 
 ## Failover Architecture Type
 
@@ -113,6 +132,14 @@ Rollback:
 *   Click on `Rerun`, under the build status for each workflow
 *   Click `Rerun from beginning`
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 Manual
@@ -127,34 +154,3 @@ They come from two sources:
 2.  The CircleCI context used in the [CircleCI config](https://github.com/Financial-Times/prometheus-ecs-discovery/blob/master/.circleci/config.yml).
 
 See the [README](https://github.com/Financial-Times/prometheus-ecs-discovery#prometheus-amazon-ecs-discovery) for more details.
-
-## First Line Troubleshooting
-
-It may be useful to view the latest targets Prometheus has read from the written config file using the targets interface for the [EU](https://prometheus-eu-west-1.in.ft.com/targets#job-application) and [US](https://prometheus-us-east-1.in.ft.com/targets#job-application) prometheus instances. If this list does not contain any instances, or does not contain the expected instance, it is likely there is an issue with the running of the ECS discovery service, or accessing the ECS API in a given region.
-
-AWS credentials are obtained using an ECS task role and so should not require keys or require human intervention due to expiry.
-
-View the generic troubleshooting information for the AWS ECS cluster (including services running on the cluster) which the application runs on: [monitoring-aggregation-ecs](https://github.com/Financial-Times/monitoring-aggregation-ecs/blob/master/documentation/RUNBOOK.md).
-
-## Second Line Troubleshooting
-
-The service discovery component runs two containers per task: each collects service discovery information for a particular region. These are written to separate files.
-
-## Monitoring
-
-The Heimdall Prometheus has some bespoke alarms which are sent to the [#rel-eng-alerts](https://financialtimes.slack.com/messages/C8QL0GY9J) Slack via alertmanager.
-
-These are visible in the [Alertmanager UI](https://alertmanager.in.ft.com/) if they are firing.
-
-There are several Grafana dashboards:
-
-*   [AWS ECS Task metrics](http://grafana.ft.com/d/YCsaeAFiz/aws-ecs-operations-and-reliability?orgId=1&var-region=eu-west-1&var-cluster=mon-agg-ecs&var-service=mon-agg-ecs-service-prometheus-ecs-discovery-Service-1OY1CGBRU4NXW) (`us-east-1` metrics are available using the dropdowns).
-*   [Go language runtime metrics](http://grafana.ft.com/d/c0mUzOcmz/go-processes?orgId=1&var-system=prometheus-ecs-discovery-exporter&var-cluster_name=All&var-container=prometheus-ecs-discovery-exporter-service&var-task_revision=All&var-instance=All&var-interval=10m) - note: this dashboard is based on metrics from containers discovered using this service, and may indicate what targets are available.
-
-Logs are available in [Splunk](https://financialtimes.splunkcloud.com/en-GB/app/search/search?q=search%20index%3D%22operations-reliability%22%20attrs.com.ft.service-name%3D%22prometheus-ecs-discovery*%22%20attrs.com.ft.service-region%3D%22*%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-1h&latest=now) via the query:
-
-```splunk
-index="operations-reliability" attrs.com.ft.service-name="prometheus-ecs-discovery-*-service" attrs.com.ft.service-region="*"
-```
-
-the `source` parameter can be specified more exactly to include only relevant component if needed.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -43,6 +43,14 @@ No
 
 No
 
+## Can Download Personal Data
+
+No
+
+## Can Contact Individuals
+
+No
+
 ## Failover Architecture Type
 
 ActiveActive


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/prometheus-ecs-discovery/blob/runbook-no-relationships-2021-03-18/RUNBOOK.md) file has been automatically regenerated from the Biz Ops data for the **prometheus-ecs-discovery** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **prometheus-ecs-discovery** system in [Biz Ops](https://biz-ops.in.ft.com/System/prometheus-ecs-discovery).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
