### PR TITLE
Select correct network interface

### DIFF
--- a/cmd/ecs-discovery/main.go
+++ b/cmd/ecs-discovery/main.go
@@ -164,7 +164,8 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 			return ret
 		}
 		for _, iface := range t.EC2Instance.NetworkInterfaces {
-			if iface.PrivateIpAddress != nil && *iface.PrivateIpAddress != "" {
+			if iface.PrivateIpAddress != nil && *iface.PrivateIpAddress != "" &&
+				strings.HasPrefix(*iface.Groups[0].GroupName, "mon-agg-ecs-ClusterInstanceSecurityGroup") {
 				ip = *iface.PrivateIpAddress
 				break
 			}

--- a/cmd/ecs-discovery/main.go
+++ b/cmd/ecs-discovery/main.go
@@ -165,7 +165,7 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 		}
 		for _, iface := range t.EC2Instance.NetworkInterfaces {
 			if iface.PrivateIpAddress != nil && *iface.PrivateIpAddress != "" &&
-				strings.HasPrefix(*iface.Groups[0].GroupName, "mon-agg-ecs-ClusterInstanceSecurityGroup") {
+				strings.HasPrefix(*iface.Groups[0].GroupName, "mon-agg-ecs-") {
 				ip = *iface.PrivateIpAddress
 				break
 			}


### PR DESCRIPTION
## Why?

-   Currently, if the ENI that ECS attaches to its EC2 instances is returned first in the list of `NetworkInterfaces` by the EC2 API, the discovery will try to use it
-  This breaks everything, because it doesn't have the correct security groups to permit access to the containers

## What?

-   When selecting an IP address, use the interface that has the `mon-agg-ecs-ClusterInstanceSecurityGroup` security group attached to it
- The code only checks for the prefix `mon-agg-ecs-`, because the group is named `mon-agg-ecs-test-ClusterInstanceSecurityGroup` in the test environment.

### Anything in particular you'd like to highlight to reviewers?

Not sure that this is the right approach long-term, but it should hopefully avoid running into the problem we saw yesterday for the time being.